### PR TITLE
HTTP request/response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,34 @@ Adds exception data to the log. Will add the message, type, stack trace and line
  }
 ```
 
+### ForceLog.Logger withRequest([String name,] HttpRequest req [, Set<String> includeHeaders])
+
+Adds HTTP request data to the log. If no name is supplied it will add it in the `request` field. Headers can be included by specifying the headers to include using the `includeHeaders` argument.
+
+```apex
+ ForceLog.Logger log = new ForceLog.Logger('myClassName');
+ HttpRequest req = new HttpRequest();
+
+ log.withRequest(req).info('got request');
+ log.withRequest('my_request', req).info('got request');
+ log.withRequest(req, new Set<String> { 'Content-Type' }).info('got request');
+ log.withRequest('my_request', req, new Set<String> { 'Content-Type' }).info('got request');
+```
+
+### ForceLog.Logger withResponse([String name,] HttpResponse res [, Set<String> excludeHeaders])
+
+Adds HTTP response data to the log. If no name is supplied it will add it in the `response` field. Headers can be excluded by specifying the headers to exclude using the `excludeHeaders` argument, e.g. if they contain credentials.
+
+```apex
+ ForceLog.Logger log = new ForceLog.Logger('myClassName');
+ HttpResponse res = new HttpResponse(); // or from Http.send()
+
+ log.withResponse(res).info('got response');
+ log.withResponse('my_response', res).info('got response');
+ log.withResponse(res, new Set<String> { 'X-Token' }).info('got response');
+ log.withResponse('my_response', res, new Set<String> { 'X-Token }).info('got response');
+```
+
 ### void dispose()
 
 Triggers the implementation of the `bulkFlush()` method when using `ForceLog.BulkLogger`.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Adds a field to the log with the specified value. Will throw a `ReservedFieldExc
 * `exception_stack_trace`
 * `exception_line_number`
 * `exception_cause`
+* `request`
+* `response`
 
 ```apex
  ForceLog.Logger log = new ForceLog.Logger('myClassName');

--- a/src/ForceLog.cls
+++ b/src/ForceLog.cls
@@ -24,6 +24,42 @@ global with sharing class ForceLog {
     }
 
     /**
+     * @description SError message for a reserved field.
+     */
+    private static String RESERVED_FIELD_ERROR = 'Field name "{0}" is reserved';
+
+    /**
+     * @description SError message for a reserved field used by withException().
+     */
+    private static String RESERVED_EXCEPTION_FIELD_ERROR = 'Field name "{0}" is reserved, use withException() instead';
+
+    /**
+     * @description SError message for a reserved field used by withRequest().
+     */
+    private static String RESERVED_REQUEST_FIELD_ERROR = 'Field name "{0}" is reserved, use withRequest() instead';
+
+    /**
+     * @description SError message for a reserved field used by withResponse().
+     */
+    private static String RESERVED_RESPONSE_FIELD_ERROR = 'Field name "{0}" is reserved, use withResponse() instead';
+
+    /**
+     * @description Map of reserved field names and their error messages.
+     */
+    private static final Map<String, String> RESERVED_FIELDS = new Map<String, String> {
+        'name' => RESERVED_FIELD_ERROR,
+        'level' => RESERVED_FIELD_ERROR,
+        'timestamp' => RESERVED_FIELD_ERROR,
+        'exception_message' => RESERVED_EXCEPTION_FIELD_ERROR,
+        'exception_type' => RESERVED_EXCEPTION_FIELD_ERROR,
+        'exception_stack_trace' => RESERVED_EXCEPTION_FIELD_ERROR,
+        'exception_line_number' => RESERVED_EXCEPTION_FIELD_ERROR,
+        'exception_cause' => RESERVED_EXCEPTION_FIELD_ERROR,
+        'request' => RESERVED_REQUEST_FIELD_ERROR,
+        'response' => RESERVED_RESPONSE_FIELD_ERROR
+    };
+
+    /**
      * @description The Logger class is responsible for producing structured
      * logs and will execute the `flush()` method every time a write method
      * is used (debug, info, warning, error, panic)
@@ -44,13 +80,6 @@ global with sharing class ForceLog {
         private String name;
 
         /**
-         * @description The level for this log, should be
-         * debug, info, warning, error or panic
-         * @type {Level}
-         */
-        private Level logLevel;
-
-        /**
          * @description Initializes a new instance of the 
          * Logger class.
          * @param {String} name The log name, should be a class or method name.
@@ -68,8 +97,7 @@ global with sharing class ForceLog {
          * @return {void}
          */
         public void debug(String message) {
-            this.logLevel = level.DEBUG;
-            this.write(message);
+            this.write(message, Level.DEBUG);
         }
 
         /**
@@ -79,8 +107,7 @@ global with sharing class ForceLog {
          * @return {void}
          */
         public void info(String message) {
-            this.logLevel = Level.INFO;
-            this.write(message);
+            this.write(message, Level.INFO);
         }
 
         /**
@@ -90,8 +117,7 @@ global with sharing class ForceLog {
          * @return {void}
          */
         public void warning(String message) {
-            this.logLevel = Level.WARNING;
-            this.write(message);
+            this.write(message, Level.WARNING);
         }
 
         /**
@@ -101,8 +127,7 @@ global with sharing class ForceLog {
          * @return {void}
          */
         public void error(String message) {
-            this.logLevel = Level.ERROR;
-            this.write(message);
+            this.write(message, Level.ERROR);
         }
 
         /**
@@ -112,8 +137,7 @@ global with sharing class ForceLog {
          * @return {void}
          */
         public void panic(String message) {
-            this.logLevel = Level.PANIC;
-            this.write(message);
+            this.write(message, Level.PANIC);
         }
 
         /**
@@ -149,41 +173,17 @@ global with sharing class ForceLog {
          */
         public Logger withField(String name, Object value) {
             // Throw a ReservedFieldException if trying to use a reserved field name.
-            switch on name {
-                when 'name' {
-                    throw new ReservedFieldException('Field name "name" is reserved');
-                }
-                when 'level' {
-                    throw new ReservedFieldException('Field name "level" is reserved');
-                }
-                when 'timestamp' {
-                    throw new ReservedFieldException('Field name "timestamp" is reserved');
-                }
-                when 'exception_message' {
-                    throw new ReservedFieldException('Field name "exception_message" is reserved, use withException() instead');
-                }
-                when 'exception_stack_trace' {
-                    throw new ReservedFieldException('Field name "exception_stack_trace" is reserved, use withException() instead');
-                }
-                when 'exception_line_number' {
-                    throw new ReservedFieldException('Field name "exception_line_number" is reserved, use withException() instead');
-                }
-                when 'exception_type' {
-                    throw new ReservedFieldException('Field name "exception_type" is reserved, use withException() instead');
-                }
-                when 'exception_cause' {
-                    throw new ReservedFieldException('Field name "exception_cause" is reserved, use withException() instead');
-                }
-                when else {
-                    this.fields.put(name, value);
-                }
+            if(RESERVED_FIELDS.keySet().contains(name)) {
+                throw new ReservedFieldException(String.format(RESERVED_FIELDS.get(name), new List<String> { name }));
+            } else {
+                this.fields.put(name, value);
             }
 
             return this;
         }
 
         /**
-         * @description Adds exception data to the log
+         * @description Adds exception data to the log.
          * @param {Exception} ex The exception to log, traverses the cause
          * of each exception to log the root cause of any exception.
          * @return {Logger} The current instance of the logger, for method chaining.
@@ -196,18 +196,140 @@ global with sharing class ForceLog {
         }
 
         /**
+         * @description Adds HttpRequest data to the log.
+         * @param {HttpRequest} req The HttpRequest to log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withRequest(HttpRequest req) {
+            return withRequest(req, new Set<String>());
+        }
+
+        /**
+         * @description Adds HttpRequest data to the log using a defined field name.
+         * @param {String} name The field name.
+         * @param {HttpRequest} req The HttpRequest to log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withRequest(String name, HttpRequest req) {
+            return withRequest(name, req, new Set<String>());
+        }
+
+        /**
+         * @description Adds HttpRequest data to the log including headers.
+         * @param {HttpRequest} req The HttpRequest to log.
+         * @param {Set<String>} includeHeaders The headers to include in the log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withRequest(HttpRequest req, Set<String> includeHeaders) {
+            return withRequest('request', req, includeHeaders);
+        }
+
+        /**
+         * @description Adds HttpRequest data to the log including headers using a defined field name.
+         * @param {String} name The field name.
+         * @param {HttpRequest} req The HttpRequest to log.
+         * @param {Set<String>} includeHeaders The headers to include in the log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withRequest(String name, HttpRequest req, Set<String> includeHeaders) {
+            Map<String, Object> requestFields = new Map<String, Object> {
+                'body' => req.getBody(),
+                'compressed' => req.getCompressed(),
+                'endpoint' => req.getEndpoint(),
+                'method' => req.getMethod()
+            };
+            
+            if (!includeHeaders.isEmpty()) {
+                // Build up the map of headers if they should be included
+                Map<String, String> headers = new Map<String, String>();
+
+                for (String header : includeHeaders) {
+                    headers.put(header, req.getHeader(header));
+                }
+
+                requestFields.put('headers', headers);
+            }
+
+            this.fields.put(name, requestFields);
+
+            return this;
+        }
+
+        /**
+         * @description Adds HttpResponse data to the log.
+         * @param {HttpResponse} res The HttpResponse to log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResponse(HttpResponse res) {
+            return withResponse(res, new Set<String>());
+        }
+
+        /**
+         * @description Adds HttpResponse data to the log using a defined field name.
+         * @param {String} name The field name.
+         * @param {HttpResponse} res The HttpResponse to log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResponse(String name, HttpResponse res) {
+            return withResponse(name, res, new Set<String>());
+        }
+
+        /**
+         * @description Adds HttpResponse data to the log excluding headers.
+         * @param {HttpResponse} res The HttpResponse to log.
+         * @param {Set<String>} excludeHeaders The headers to exclude from the log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResponse(HttpResponse res, Set<String> excludeHeaders) {
+            return withResponse('response', res, excludeHeaders);
+        }
+
+        /**
+         * @description Adds HttpResponse data to the log excluding headers using a defined field name.
+         * @param {String} name The field name.
+         * @param {HttpResponse} res The HttpResponse to log.
+         * @param {Set<String>} excludeHeaders The headers to exclude from the log.
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResponse(String name, HttpResponse res, Set<String> excludeHeaders) {
+            Map<String, Object> responseFields = new Map<String, Object> {
+                'body' => res.getBody(),
+                'status' => res.getStatus(),
+                'status_code' => res.getStatusCode()
+            };
+
+            // Build up the map of headers
+            Map<String, String> headers = new Map<String, String>();
+
+            for (String header : res.getHeaderKeys()) {
+                if(!excludeHeaders.contains(header)) {
+                    headers.put(header, res.getHeader(header));
+                }
+            }
+
+            if(!headers.isEmpty()) {
+                responseFields.put('headers', headers);
+            }
+
+            this.fields.put(name, responseFields);
+
+            return this;
+        }
+
+        /**
          * @description Converts the log into an instance of
          * Map<String, Object> containing all provided fields
          * and exception details. This map is then passed to the
          * provided implementation of the flush() method.
          * @param {String} message The log message
+         * @param {Level} logLevel The level for this log, should be debug, info, warning, error or panic
          * @return {void}
          */
-        private void write(String message) {
+        private void write(String message, Level logLevel) {
             // Create map containing default logging fields.
             Map<String, Object> log = new Map<String, Object> {
                 'message' => message,
-                'level' => this.logLevel.name().toLowerCase(),
+                'level' => logLevel.name().toLowerCase(),
                 'name' => this.name,
                 'timestamp' => Datetime.now()
             };
@@ -218,13 +340,8 @@ global with sharing class ForceLog {
             // Invoke log flushing implementation.
             this.flush(log);
 
-            // Remove exception fields if present as these have
-            // already been logged.
-            this.fields.remove('exception_message');
-            this.fields.remove('exception_stack_trace');
-            this.fields.remove('exception_line_number');
-            this.fields.remove('exception_type');
-            this.fields.remove('exception_cause');
+            // Remove fields if present as these have already been logged.
+            this.fields.clear();
         }
     }
 

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -127,6 +127,50 @@ private class ForceLogTest {
     }
 
     @isTest
+    private static void itShouldAddHttpRequestDetails() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('request', '*');
+
+        logger.withRequest(new HttpRequest()).error('test');
+    }
+
+    @isTest
+    private static void itShouldAddHttpRequestDetailsWithName() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('test_request', '*');
+
+        logger.withRequest('test_request', new HttpRequest()).error('test');
+    }
+
+    @isTest
+    private static void itShouldAddHttpResponseDetails() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('response', '*');
+
+        logger.withResponse(new HttpResponse()).error('test');
+    }
+
+    @isTest
+    private static void itShouldAddHttpResponseDetailsWithName() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('test_response', '*');
+
+        logger.withResponse('test_response', new HttpResponse()).error('test');
+    }
+
+    @isTest
     private static void itShouldNotAllowReservedNames() {
         TestLogger logger = new TestLogger('test');
 
@@ -138,7 +182,9 @@ private class ForceLogTest {
             'exception_type',
             'exception_stack_trace',
             'exception_line_number',
-            'exception_cause'
+            'exception_cause',
+            'request',
+            'response'
         };
 
         for (String name : names) {
@@ -277,7 +323,7 @@ private class ForceLogTest {
                     // If we only care about the field existing, ensure
                     // it is not null.
                     if (expVal == '*') {
-                        System.assertNotEquals(null, actVal);
+                        System.assertNotEquals(null, actVal, String.format('{0} {1}', new List<String> { expKey, JSON.serialize(log) }));
                         return;
                     }
 

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -132,9 +132,18 @@ private class ForceLogTest {
 
         logger.expect('level', 'error');
         logger.expect('message', 'test');
-        logger.expect('request', '*');
+        logger.expect('request', new Map<String, Object> {
+            'body' => '',
+            'compressed' => false,
+            'endpoint' => 'test_endpoint',
+            'method' => 'GET'
+        });
 
-        logger.withRequest(new HttpRequest()).error('test');
+        HttpRequest req = new HttpRequest();
+        req.setMethod('GET');
+        req.setEndpoint('test_endpoint');
+
+        logger.withRequest(req).error('test');
     }
 
     @isTest
@@ -143,9 +152,18 @@ private class ForceLogTest {
 
         logger.expect('level', 'error');
         logger.expect('message', 'test');
-        logger.expect('test_request', '*');
+        logger.expect('test_request', new Map<String, Object> {
+            'body' => '',
+            'compressed' => false,
+            'endpoint' => 'test_endpoint',
+            'method' => 'GET'
+        });
 
-        logger.withRequest('test_request', new HttpRequest()).error('test');
+        HttpRequest req = new HttpRequest();
+        req.setMethod('GET');
+        req.setEndpoint('test_endpoint');
+        
+        logger.withRequest('test_request', req).error('test');
     }
 
     @isTest
@@ -154,9 +172,17 @@ private class ForceLogTest {
 
         logger.expect('level', 'error');
         logger.expect('message', 'test');
-        logger.expect('response', '*');
+        logger.expect('response', new Map<String, Object> {
+            'body' => '',
+            'status' => 'OK',
+            'status_code' => 200
+        });
 
-        logger.withResponse(new HttpResponse()).error('test');
+        HttpResponse res = new HttpResponse();
+        res.setStatus('OK');
+        res.setStatusCode(200);
+
+        logger.withResponse(res).error('test');
     }
 
     @isTest
@@ -165,9 +191,17 @@ private class ForceLogTest {
 
         logger.expect('level', 'error');
         logger.expect('message', 'test');
-        logger.expect('test_response', '*');
+        logger.expect('test_response', new Map<String, Object> {
+            'body' => '',
+            'status' => 'OK',
+            'status_code' => 200
+        });
 
-        logger.withResponse('test_response', new HttpResponse()).error('test');
+        HttpResponse res = new HttpResponse();
+        res.setStatus('OK');
+        res.setStatusCode(200);
+
+        logger.withResponse('test_response', res).error('test');
     }
 
     @isTest

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -186,6 +186,31 @@ private class ForceLogTest {
     }
 
     @isTest
+    private static void itShouldIncludeHttpRequestHeaders() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('test_request', new Map<String, Object> {
+            'body' => '',
+            'compressed' => false,
+            'endpoint' => 'test_endpoint',
+            'headers' => new Map<String, String> {
+                'X-Header-2' => 'test_header_2'
+            },
+            'method' => 'GET'
+        });
+
+        HttpRequest req = new HttpRequest();
+        req.setHeader('X-Header-1', 'test_header_1');
+        req.setHeader('X-Header-2', 'test_header_2');
+        req.setMethod('GET');
+        req.setEndpoint('test_endpoint');
+        
+        logger.withRequest('test_request', req, new Set<String> { 'X-Header-2' }).error('test');
+    }
+
+    @isTest
     private static void itShouldAddHttpResponseDetailsWithName() {
         TestLogger logger = new TestLogger('test');
 
@@ -202,6 +227,30 @@ private class ForceLogTest {
         res.setStatusCode(200);
 
         logger.withResponse('test_response', res).error('test');
+    }
+
+    @isTest
+    private static void itShouldExcludeHttpResponseHeaders() {
+        TestLogger logger = new TestLogger('test');
+
+        logger.expect('level', 'error');
+        logger.expect('message', 'test');
+        logger.expect('test_response', new Map<String, Object> {
+            'body' => '',
+            'headers' => new Map<String, String> {
+                'X-Header-2' => 'test_header_2'
+            },
+            'status' => 'OK',
+            'status_code' => 200
+        });
+
+        HttpResponse res = new HttpResponse();
+        res.setHeader('X-Header-1', 'test_header_1');
+        res.setHeader('X-Header-2', 'test_header_2');
+        res.setStatus('OK');
+        res.setStatusCode(200);
+
+        logger.withResponse('test_response', res, new Set<String> { 'X-Header-1' }).error('test');
     }
 
     @isTest


### PR DESCRIPTION
* Add `withRequest` and `withResponse` methods/overloads.
* Refactor reserved fields implementation.
* Clear the fields map once the log is written.
* Changed the internal `write` method so the `logLevel` variable can be removed.
* Updated `README`.