### PR TITLE
Added DML result logging

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -13,12 +13,6 @@
       <property name="minimum" value="4" />
     </properties>
   </rule>
-  <rule ref="category/apex/design.xml/ExcessivePublicCount" message="This class has too many public methods and attributes">
-    <priority>3</priority>
-    <properties>
-      <property name="minimum" value="25" />
-    </properties>
-  </rule>
   <rule ref="category/apex/design.xml/NcssConstructorCount" message="The constructor has an NCSS line count of {0}">
     <priority>3</priority>
     <properties>
@@ -54,10 +48,6 @@
     <properties>
       <property name="problemDepth" value="4" />
     </properties>
-  </rule>
-  <rule ref="category/apex/design.xml/CyclomaticComplexity">
-    <priority>3</priority>
-    <properties />
   </rule>
     <rule ref="category/apex/performance.xml/AvoidSoqlInLoops" message="Avoid Soql queries inside loops">
     <priority>3</priority>

--- a/src/ForceLog.cls
+++ b/src/ForceLog.cls
@@ -15,7 +15,7 @@ public with sharing class ForceLog {
     /**
      * @description Supported log levels.
      */
-    public enum Level {
+    private enum Level {
         DEBUG,
         INFO,
         WARNING,
@@ -314,6 +314,160 @@ public with sharing class ForceLog {
             this.fields.put(name, responseFields);
 
             return this;
+        }
+
+        /**
+         * @description Adds a single instance of Database.SaveResult to the log
+         * @param {Database.SaveResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(Database.SaveResult res) {
+            return this.withResult('result', res);
+        }
+
+        /**
+         * @description Adds a single instance of Database.DeleteResult to the log
+         * @param {Database.DeleteResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(Database.DeleteResult res) {
+            return this.withResult('result', res);
+        }
+
+        /**
+         * @description Adds a single instance of Database.UpsertResult to the log
+         * @param {Database.UpsertResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(Database.UpsertResult res) {
+            return this.withResult('result', res);
+        }
+
+        /**
+         * @description Adds a single instance of Database.DeleteResult to the log under
+         * a given key
+         * @param {String} key The key where the save result will be nested in the log.
+         * @param {Database.DeleteResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(String key, Database.DeleteResult res) {
+            Map<String, Object> entry = new Map<String, Object>{
+                'id' => res.getId(),
+                'success' => res.isSuccess(),
+                'errors' => this.formatDatabaseErrors(res.getErrors()),
+                'type' => 'delete'
+            };
+
+            return this.withField(key, entry);
+        }
+
+        /**
+         * @description Adds a single instance of Database.SaveResult to the log under
+         * a given key
+         * @param {String} key The key where the save result will be nested in the log.
+         * @param {Database.SaveResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(String key, Database.SaveResult res) {
+            Map<String, Object> entry = new Map<String, Object>{
+                'id' => res.getId(),
+                'success' => res.isSuccess(),
+                'errors' => this.formatDatabaseErrors(res.getErrors()),
+                'type' => 'save'
+            };
+
+            return this.withField(key, entry);
+        }
+
+        /**
+         * @description Adds a single instance of Database.UpsertResult to the log under
+         * a given key
+         * @param {String} key The key where the save result will be nested in the log.
+         * @param {Database.UpsertResult} res The database result to log
+         * @returns {Logger} The current instance of the logger, for method chaining.
+         */
+        public Logger withResult(String key, Database.UpsertResult res) {
+            Map<String, Object> entry = new Map<String, Object>{
+                'id' => res.getId(),
+                'success' => res.isSuccess(),
+                'errors' => this.formatDatabaseErrors(res.getErrors()),
+                'created' => res.isCreated(),
+                'type' => 'upsert'
+            };
+
+            return this.withField(key, entry);
+        }
+
+        public Logger withResults(List<Database.SaveResult> results) {
+            return this.withResults('results', results);
+        }
+
+        public Logger withResults(List<Database.UpsertResult> results) {
+            return this.withResults('results', results);
+        }
+
+        public Logger withResults(List<Database.DeleteResult> results) {
+            return this.withResults('results', results);
+        }
+
+        public Logger withResults(String key, List<Database.SaveResult> results) {
+            List<Object> entry = new List<Object>();
+
+            for (Database.SaveResult res : results) {
+                entry.Add(new Map<String, Object>{
+                    'id' => res.getId(),
+                    'success' => res.isSuccess(),
+                    'errors' => this.formatDatabaseErrors(res.getErrors()),
+                    'type' => 'save'
+                });           
+            }
+
+            return this.withField(key, entry);
+        }
+
+        public Logger withResults(String key, List<Database.UpsertResult> results) {
+            List<Object> entry = new List<Object>();
+
+            for (Database.UpsertResult res : results) {
+                entry.Add(new Map<String, Object>{
+                    'id' => res.getId(),
+                    'success' => res.isSuccess(),
+                    'errors' => this.formatDatabaseErrors(res.getErrors()),
+                    'type' => 'upsert',
+                    'created' => res.isCreated()
+                });           
+            }
+
+            return this.withField(key, entry);
+        }
+
+        public Logger withResults(String key, List<Database.DeleteResult> results) {
+            List<Object> entry = new List<Object>();
+
+            for (Database.DeleteResult res : results) {
+                entry.Add(new Map<String, Object>{
+                    'id' => res.getId(),
+                    'success' => res.isSuccess(),
+                    'errors' => this.formatDatabaseErrors(res.getErrors()),
+                    'type' => 'delete'
+                });           
+            }
+
+            return this.withField(key, entry);
+        }
+
+        private List<Object> formatDatabaseErrors(List<Database.Error> errs) {
+            List<Object> output = new List<Object>();
+
+            for (Database.Error err : errs) {
+                output.add(new Map<String, Object> {
+                    'fields' => err.getFields(),
+                    'message' => err.getMessage(),
+                    'code' => err.getStatusCode()
+                });
+            }
+
+            return output;
         }
 
         /**

--- a/src/ForceLog.cls
+++ b/src/ForceLog.cls
@@ -319,7 +319,7 @@ public with sharing class ForceLog {
         /**
          * @description Adds a single instance of Database.SaveResult to the log
          * @param {Database.SaveResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(Database.SaveResult res) {
             return this.withResult('result', res);
@@ -328,7 +328,7 @@ public with sharing class ForceLog {
         /**
          * @description Adds a single instance of Database.DeleteResult to the log
          * @param {Database.DeleteResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(Database.DeleteResult res) {
             return this.withResult('result', res);
@@ -337,7 +337,7 @@ public with sharing class ForceLog {
         /**
          * @description Adds a single instance of Database.UpsertResult to the log
          * @param {Database.UpsertResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(Database.UpsertResult res) {
             return this.withResult('result', res);
@@ -348,7 +348,7 @@ public with sharing class ForceLog {
          * a given key
          * @param {String} key The key where the save result will be nested in the log.
          * @param {Database.DeleteResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(String key, Database.DeleteResult res) {
             Map<String, Object> entry = new Map<String, Object>{
@@ -366,7 +366,7 @@ public with sharing class ForceLog {
          * a given key
          * @param {String} key The key where the save result will be nested in the log.
          * @param {Database.SaveResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(String key, Database.SaveResult res) {
             Map<String, Object> entry = new Map<String, Object>{
@@ -384,7 +384,7 @@ public with sharing class ForceLog {
          * a given key
          * @param {String} key The key where the save result will be nested in the log.
          * @param {Database.UpsertResult} res The database result to log
-         * @returns {Logger} The current instance of the logger, for method chaining.
+         * @return {Logger} The current instance of the logger, for method chaining.
          */
         public Logger withResult(String key, Database.UpsertResult res) {
             Map<String, Object> entry = new Map<String, Object>{

--- a/src/ForceLog.cls
+++ b/src/ForceLog.cls
@@ -398,18 +398,38 @@ public with sharing class ForceLog {
             return this.withField(key, entry);
         }
 
+        /**
+         * @description Adds a list of Database.SaveResult to the log data.
+         * @param {List<Database.SaveResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(List<Database.SaveResult> results) {
             return this.withResults('results', results);
         }
 
+        /**
+         * @description Adds a list of Database.UpsertResult to the log data.
+         * @param {List<Database.UpsertResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(List<Database.UpsertResult> results) {
             return this.withResults('results', results);
         }
 
+        /**
+         * @description Adds a list of Database.DeleteResult to the log data.
+         * @param {List<Database.DeleteResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(List<Database.DeleteResult> results) {
             return this.withResults('results', results);
         }
 
+        /**
+         * @description Adds a list of Database.SaveResult to the log data.
+         * @param {List<Database.SaveResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(String key, List<Database.SaveResult> results) {
             List<Object> entry = new List<Object>();
 
@@ -425,6 +445,13 @@ public with sharing class ForceLog {
             return this.withField(key, entry);
         }
 
+        /**
+         * @description Adds a list of Database.UpsertResult to the log data under
+         * a given key.
+         * @param {String} key The key to nest the result data.
+         * @param {List<Database.UpsertResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(String key, List<Database.UpsertResult> results) {
             List<Object> entry = new List<Object>();
 
@@ -441,6 +468,13 @@ public with sharing class ForceLog {
             return this.withField(key, entry);
         }
 
+        /**
+         * @description Adds a list of Database.DeleteResult to the log data under
+         * a given key.
+         * @param {String} key The key to nest the result data.
+         * @param {List<Database.DeleteResult>} results The database results to log
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */
         public Logger withResults(String key, List<Database.DeleteResult> results) {
             List<Object> entry = new List<Object>();
 
@@ -456,6 +490,12 @@ public with sharing class ForceLog {
             return this.withField(key, entry);
         }
 
+        /**
+         * @description Converts an instance of List<Database.Errors> into a 
+         * list of objects that can be safely serialized.
+         * @param {List<Database.Error>} errs The errors to convert
+         * @return {List<Object>} The result of the conversion.
+         */
         private List<Object> formatDatabaseErrors(List<Database.Error> errs) {
             List<Object> output = new List<Object>();
 

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -154,6 +154,34 @@ private class ForceLogTest {
     }
 
     @isTest
+    private static void itShouldAddUpsertResult() {
+        TestLogger logger = new TestLogger('test');
+
+        Contact c = new Contact(
+            FirstName = 'tester',
+            LastName = 'mctest',
+            Email = 'unit@test.com'
+        );
+
+        Database.UpsertResult result = Database.upsert(c);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('result', new Map<String, Object> {
+            'id' => result.getId(),
+            'success' => result.isSuccess(),
+            'errors' => new List<Object>(),
+            'created' => result.isCreated(),
+            'type' => 'upsert'
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResult(result).info('test');        
+    }
+
+
+    @isTest
     private static void itShouldAddDeleteResult() {
         TestLogger logger = new TestLogger('test');
 

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -127,6 +127,86 @@ private class ForceLogTest {
     }
 
     @isTest
+    private static void itShouldAddUpsertResult() {
+        TestLogger logger = new TestLogger('test');
+
+        Contact c = new Contact(
+            FirstName = 'tester',
+            LastName = 'mctest',
+            Email = 'unit@test.com'
+        );
+
+        Database.UpsertResult result = Database.upsert(c);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('result', new Map<String, Object> {
+            'id' => result.getId(),
+            'success' => result.isSuccess(),
+            'errors' => new List<Object>(),
+            'created' => result.isCreated(),
+            'type' => 'upsert'
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResult(result).info('test');        
+    }
+
+    @isTest
+    private static void itShouldAddDeleteResult() {
+        TestLogger logger = new TestLogger('test');
+
+        Contact c = new Contact(
+            FirstName = 'tester',
+            LastName = 'mctest',
+            Email = 'unit@test.com'
+        );
+
+        insert c;
+        Database.DeleteResult result = Database.delete(c);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('result', new Map<String, Object> {
+            'id' => result.getId(),
+            'success' => result.isSuccess(),
+            'errors' => new List<Object>(),
+            'type' => 'delete'
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResult(result).info('test');        
+    }
+
+    @isTest
+    private static void itShouldAddSaveResult() {
+        TestLogger logger = new TestLogger('test');
+
+        Contact c = new Contact(
+            FirstName = 'tester',
+            LastName = 'mctest',
+            Email = 'unit@test.com'
+        );
+
+        Database.SaveResult result = Database.insert(c);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('result', new Map<String, Object> {
+            'id' => result.getId(),
+            'success' => result.isSuccess(),
+            'errors' => new List<Object>(),
+            'type' => 'save'
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResult(result).info('test');        
+    }
+
+    @isTest
     private static void itShouldAddHttpRequestDetails() {
         TestLogger logger = new TestLogger('test');
 

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -154,32 +154,35 @@ private class ForceLogTest {
     }
 
     @isTest
-    private static void itShouldAddUpsertResult() {
+    private static void itShouldAddUpsertResults() {
         TestLogger logger = new TestLogger('test');
 
-        Contact c = new Contact(
-            FirstName = 'tester',
-            LastName = 'mctest',
-            Email = 'unit@test.com'
-        );
+        List<Contact> contacts = new List<Contact> {
+            new Contact(
+                FirstName = 'tester',
+                LastName = 'mctest',
+                Email = 'unit@test.com'
+            )
+        };
 
-        Database.UpsertResult result = Database.upsert(c);
+        List<Database.UpsertResult> results = Database.upsert(contacts);
 
         logger.expect('level', 'info');
         logger.expect('message', 'test');
-        logger.expect('result', new Map<String, Object> {
-            'id' => result.getId(),
-            'success' => result.isSuccess(),
-            'errors' => new List<Object>(),
-            'created' => result.isCreated(),
-            'type' => 'upsert'
+        logger.expect('results', new List<Object>{
+            new Map<String, Object> {
+                'id' => results.get(0).getId(),
+                'success' => results.get(0).isSuccess(),
+                'errors' => new List<Object>(),
+                'created' => results.get(0).isCreated(),
+                'type' => 'upsert'
+            }
         });
         logger.expect('timestamp', '*');
         logger.expect('name', 'test');
 
-        logger.withResult(result).info('test');        
+        logger.withResults(results).info('test');        
     }
-
 
     @isTest
     private static void itShouldAddDeleteResult() {
@@ -206,6 +209,95 @@ private class ForceLogTest {
         logger.expect('name', 'test');
 
         logger.withResult(result).info('test');        
+    }
+
+    @isTest
+    private static void itShouldAddDeleteResults() {
+        TestLogger logger = new TestLogger('test');
+
+        List<Contact> contacts = new List<Contact> {
+            new Contact(
+                FirstName = 'tester',
+                LastName = 'mctest',
+                Email = 'unit@test.com'
+            )
+        };
+
+        insert contacts;
+        List<Database.DeleteResult> results = Database.delete(contacts);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('results', new List<Object>{
+            new Map<String, Object> {
+                'id' => results.get(0).getId(),
+                'success' => results.get(0).isSuccess(),
+                'errors' => new List<Object>(),
+                'type' => 'delete'
+            }
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResults(results).info('test');        
+    }
+
+    @isTest
+    private static void itShouldAddDatabaseErrors() {
+        TestLogger logger = new TestLogger('test');
+
+        Contact c = new Contact();
+
+        Database.SaveResult result = Database.insert(c, false);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('result', new Map<String, Object> {
+            'id' => result.getId(),
+            'success' => result.isSuccess(),
+            'errors' => new List<Object>{
+                new Map<String, Object> {
+                    'fields' => result.getErrors().get(0).getFields(),
+                    'message' => result.getErrors().get(0).getMessage(),
+                    'code' => result.getErrors().get(0).getStatusCode()
+                }
+            },
+            'type' => 'save'
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResult(result).info('test');        
+    }
+
+    @isTest
+    private static void itShouldAddSaveResults() {
+        TestLogger logger = new TestLogger('test');
+
+        List<Contact> contacts = new List<Contact> {
+            new Contact(
+                FirstName = 'tester',
+                LastName = 'mctest',
+                Email = 'unit@test.com'
+            )
+        };
+
+        List<Database.SaveResult> results = Database.insert(contacts);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('results', new List<Object>{
+            new Map<String, Object> {
+                'id' => results.get(0).getId(),
+                'success' => results.get(0).isSuccess(),
+                'errors' => new List<Object>(),
+                'type' => 'save'
+            }
+        });
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+
+        logger.withResults(results).info('test');        
     }
 
     @isTest


### PR DESCRIPTION
* Added methods `withResult` and `withResults` with overloads for supporting `Database.DeleteResult`, `Database.UpsertResult` and `Database.SaveResult`
* Added tests
* README changes still outstanding
* Removed rule for number of public methods in class, can't really help that
* Removed rule for total cyclomatic complexity