### PR TITLE
Added logging support for Database.QueryLocator

### DIFF
--- a/src/ForceLog.cls
+++ b/src/ForceLog.cls
@@ -537,6 +537,16 @@ public with sharing class ForceLog {
         }
 
         /**
+         * @description Adds the SOQL query from an instance of Database.QueryLocator to
+         * the log
+         * @param {Database.QueryLocator} ql The query locator
+         * @return {Logger} The current instance of the logger, for method chaining.
+         */ 
+        public Logger withQuery(Database.QueryLocator ql) {
+            return this.withField('query', ql.getQuery());
+        }
+
+        /**
          * @description Adds a single instance of Database.SaveResult to the log
          * @param {Database.SaveResult} res The database result to log
          * @return {Logger} The current instance of the logger, for method chaining.

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -793,7 +793,7 @@ private class ForceLogTest {
     @isTest
     private static void itShouldAddSOQLQueries() {
         TestLogger logger = new TestLogger('test');
-        Database.QueryLocator ql = new Database.QueryLocator([
+        Database.QueryLocator ql = new Database.getQueryLocator([
             SELECT ID
             FROM Contact
             LIMIT 1

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -790,6 +790,24 @@ private class ForceLogTest {
         logger.dispose();
     }
 
+    @isTest
+    private static void itShouldAddSOQLQueries() {
+        TestLogger logger = new TestLogger('test');
+        Database.QueryLocator ql = new Database.QueryLocator([
+            SELECT ID
+            FROM Contact
+            LIMIT 1
+        ]);
+
+        logger.expect('level', 'info');
+        logger.expect('message', 'test');
+        logger.expect('timestamp', '*');
+        logger.expect('name', 'test');
+        logger.expect('query', ql.getQuery());
+
+        logger.withQuery(ql).info('test');        
+    }
+
     /**
      * @description Basic exception for use in tests.
      */

--- a/src/tests/ForceLogTest.cls
+++ b/src/tests/ForceLogTest.cls
@@ -793,7 +793,7 @@ private class ForceLogTest {
     @isTest
     private static void itShouldAddSOQLQueries() {
         TestLogger logger = new TestLogger('test');
-        Database.QueryLocator ql = new Database.getQueryLocator([
+        Database.QueryLocator ql = Database.getQueryLocator([
             SELECT ID
             FROM Contact
             LIMIT 1


### PR DESCRIPTION
* You can now log your SOQL queries by using `withQuery` with an instance of `Database.QueryLocator`